### PR TITLE
Add .hgignore_global and fix path in hgrc

### DIFF
--- a/.hgignore_global
+++ b/.hgignore_global
@@ -1,0 +1,10 @@
+syntax: glob
+.DS_Store?
+.DS_Store
+*.pyc
+.svn
+Thumbs.db
+Icon?
+*.swp
+tags
+*.swo

--- a/.hgrc
+++ b/.hgrc
@@ -10,7 +10,7 @@ attend = annotate, cat, diff, export, glog, log, qdiff, slog, dlog, gslog, sglog
 username = FIRST LAST <YOUR_EMAIL@khanacademy.org>
 
 # Global .hgignore file
-ignore = ~/dotfiles/.hgignore_global
+ignore = ~/.hgignore_global
 
 [web]
 # TODO: See http://kiln.stackexchange.com/questions/2816/mercurial-certificate-warning-certificate-not-verified-web-cacerts


### PR DESCRIPTION
.hgignore_global wasn't in the repo, and it was in the hgrc - also, the hgrc referenced a `~/dotfiles` folder that people cloning this won't have.
