### PR TITLE
Change ~/dotfiles references to ~/khan-dotfiles, update README

### DIFF
--- a/.hgrc
+++ b/.hgrc
@@ -43,12 +43,12 @@ nudge = push --rev .
 # What did I do today?
 today = !hg log --template '{rev} {desc|firstline|strip}\n' -r "sort(user('$(hg showconfig ui.username | sed 's/.*<\(.*\)>/\1/')') and date(-1), -date)"
 
-slog = log --style=$HOME/dotfiles/mercurial-cli-templates/map-cmdline.slog
-nlog = log --style=$HOME/dotfiles/mercurial-cli-templates/map-cmdline.nlog
-sglog = glog --style=$HOME/dotfiles/mercurial-cli-templates/map-cmdline.sglog
+slog = log --style=$HOME/khan-dotfiles/mercurial-cli-templates/map-cmdline.slog
+nlog = log --style=$HOME/khan-dotfiles/mercurial-cli-templates/map-cmdline.nlog
+sglog = glog --style=$HOME/khan-dotfiles/mercurial-cli-templates/map-cmdline.sglog
 gslog = sglog
-dlog = log --style=$HOME/dotfiles/mercurial-cli-templates/map-cmdline.dlog
-lga = glog --style=$HOME/dotfiles/mercurial-cli-templates/map-cmdline.lg
+dlog = log --style=$HOME/khan-dotfiles/mercurial-cli-templates/map-cmdline.dlog
+lga = glog --style=$HOME/khan-dotfiles/mercurial-cli-templates/map-cmdline.lg
 lg = lga --rev 'ancestors(.)'
 st = st -S
 df = diff

--- a/README.markdown
+++ b/README.markdown
@@ -17,8 +17,9 @@ This is meant to complement [the dev setup on the Khan Academy Forge](https://si
 
 Setup
 -----
-Clone this repo and then run `make` in the cloned directory.
+Clone this repo into your home directory and then run `make` in the cloned directory.
 
+    cd ~
     git clone git://github.com/divad12/khan-dotfiles.git
     cd khan-dotfiles
     make


### PR DESCRIPTION
None of the mercurial-cli-templates will work without this because they're in
the wrong path - people will be cloning into ~/khan-dotfiles, not ~/dotfiles.

Also, everyone should clone in their home directory, so there's a predictable
path when paths need to be hardcoded.

(I haven't been testing these because I don't have a convenient way of doing so without nuking my existing environment, so please read carefully)
